### PR TITLE
Select radio by label update for User Rights page

### DIFF
--- a/step_definitions/interactions.js
+++ b/step_definitions/interactions.js
@@ -926,16 +926,6 @@ Given("I close the iframe window", () => {
 
 /**
  * @module Interactions
- * @author Sumon Chattopadhyay <sumon.chattopadhyay@utah.edu>
- * @example I close the popup
- * @description Closes the pop up
- */
-Given("I close the popup", () => {
-    cy.get('button').contains("Close").click()
-})
-
-/**
- * @module Interactions
  * @author Adam De Fouw <aldefouw@medicine.wisc.edu>
  * @example I click on the table heading column labeled {string}
  * @param {string} column - the text to enter into the field

--- a/step_definitions/interactions.js
+++ b/step_definitions/interactions.js
@@ -931,7 +931,7 @@ Given("I close the iframe window", () => {
  * @description Closes the pop up
  */
 Given("I close the popup", () => {
-    cy.click_on_dialog_button("Close")
+    cy.get('button').contains("Close").click()
 })
 
 /**


### PR DESCRIPTION
"I select the radio option "No Access" for the field labeled "User Rights" in the dialog box" in [B.2.6.100 - Basic Privileges](https://github.com/4bbakers/redcap_rsvc/tree/v14.7.0/Feature%20Tests/B/Assign%20User%20Rights_6/B.2.6.100%20-%20Basic%20Privileges.feature) fails since it cannot properly select the radio button in the User Rights page.

This fix lets the browser select the User Rights radio buttons properly. I know this command actually lives in `online_designer.js` but I was still able to writ the Gherkin to properly work. Let me know if I should try a different approach and I'd be happy to modify the feature tests as well.