### PR TITLE
Improved sibling radio label matching

### DIFF
--- a/commands/online_designer.js
+++ b/commands/online_designer.js
@@ -106,7 +106,22 @@ Cypress.Commands.add('select_radio_by_label', ($name, $value, $click = true, $se
             }
         } else {
             // Fallback to the nearest radio button - whether that is next or previous parent
+            const action = (radio) => {
+                if ($click) {
+                    radio.click()
+                } else {
+                    radio.should('have.attr', $selected ? 'checked' : 'unchecked')
+                }
+            }
+
             cy.contains($value).then($text => {
+                const radios = $text.find('input[type=radio]')
+                if (radios.length === 1) {
+                    // The the text and matching radio are the only siblings within a div (e.g. "Lock/Unlock Records").
+                    action(radios[0])
+                    return
+                }
+
                 const parent = Cypress.$($text).parent()
                 let radio = parent
 
@@ -117,11 +132,7 @@ Cypress.Commands.add('select_radio_by_label', ($name, $value, $click = true, $se
                 }
 
                 if (radio.length) {
-                    if ($click) {
-                        cy.wrap(radio).find('input[type=radio]').click();
-                    } else {
-                        cy.wrap(radio).find('input[type=radio]').should('have.attr', $selected ? 'checked' : 'unchecked');
-                    }
+                    cy.wrap(radio).find('input[type=radio]').then(action)
                 }
             })
         }


### PR DESCRIPTION
@aldefouw, I'm trying to make progress on everything we discussed yesterday while it's fresh in our minds (so we don't have to get up to speed multiple times on it).  This separates the radio label matching commit from the "top most dialog" commit in https://github.com/aldefouw/rctf/pull/21 so that we can go ahead and merge this while I work on an alternate implementation for the dialog change.  The cloud build results in the description of https://github.com/aldefouw/rctf/pull/21 confirm that this is safe to merge.