### PR TITLE
Made variations of 'Logic Editor' steps work as expected

### DIFF
--- a/step_definitions/interactions.js
+++ b/step_definitions/interactions.js
@@ -494,6 +494,7 @@ Given ('I {enterType} {string} in(to) the( ){ordinal}( )textarea field {labeledE
     //Turns out the logic editor uses a DIV with an "Ace Editor" somehow /shrug
     if(label === "Logic Editor") {
         element = `div#rc-ace-editor div.ace_line`
+        enter_type = 'clear field and enter'
     }
 
     //Either the base element as specified or the default


### PR DESCRIPTION
@aldefouw, no worries if you want to ignore this.  I'll can just send it to Kyle once the repos are moved.

A few dozen lines below this one the special handling for the `Logic Editor` label is only implemented when using `clear field and enter` .  All other `enter_type`'s currently fail in a way that is confusing and difficult to troubleshoot.  This change improves the behavior in this case such that all `enter_type`'s perform as if `clear field and enter` was used.  This will allow the current step to proceed regardless.  This may lead to a later step failing if clearing the field is not desired, but that behavior is much preferred to current behavior.