### PR TITLE
Match inputs missing types

### DIFF
--- a/step_definitions/interactions.js
+++ b/step_definitions/interactions.js
@@ -390,6 +390,10 @@ Given("I click on the button labeled {string} for the row labeled {string}", (te
  */
 Given('I {enterType} {string} (into)(is within) the( ){ordinal}( ){inputType} field( ){columnLabel}( ){labeledExactly} {string}{baseElement}{iframeVisibility}', (enter_type, text, ordinal, input_type, column, labeled_exactly, label, base_element, iframe) => {
     let select = 'input[type=text]:visible,input[type=password]:visible'
+
+    // Also look for inputs that omit a "type", like "Name of trigger"
+    select += ',input:not([type]):visible'
+
     if(input_type === 'password'){
         select = 'input[type=password]:visible'
     }


### PR DESCRIPTION
@aldefouw, no worries if you want to ignore this.  I'll can just send it to Kyle once the repos are moved.

This allows inputs to be matched that omit the `type` attribute (and to 'text').  This change does not affect build results, as shown here:
![image](https://github.com/user-attachments/assets/41fabdbc-bd77-4b2b-b957-f89f621d2048)
