### PR TITLE
Marks changes

### DIFF
--- a/commands/base.js
+++ b/commands/base.js
@@ -91,6 +91,14 @@ Cypress.Commands.add('not_loading', () => {
         })
     }
 
+    /**
+     * The 'if' checks below don't work properly 100% of the time because there is a race condition
+     * if the page happens to reload between the 'Cypress.$' and the 'cy.get()' calls,
+     * and the latter page no longer contains the specified div.
+     * I think we may want to deprecate the not_loading() command in favor of steps that
+     * look for something guaranteed to exist on the next page.
+     * That could be as simple as an "I should see" step specifying some text.
+     */
     if(Cypress.$('span#progress_save').length) cy.get('span#progress_save').should('not.be.visible')
     if(Cypress.$('div#progress').length) cy.get('div#progress').should('not.be.visible')
     if(Cypress.$('div#working').length) cy.get('div#working', { timeout: 30000 }).should('not.be.visible')

--- a/step_definitions/visibilty.js
+++ b/step_definitions/visibilty.js
@@ -188,8 +188,6 @@ Given("I should see {string} in the data entry form field {string}", function (f
  * @description Verifies that a visible element of the specified type containing `text` exists
  */
 Given("I (should )see( ){articleType}( ){visibilityPrefix}( ){onlineDesignerButtons}( ){labeledElement}( ){labeledExactly}( ){string}{baseElement}{iframeVisibility}( )( that){disabled}", (article_type, prefix, online_buttons, el, labeled_exactly, text, base_element, iframe, disabled_text) => {
-    cy.not_loading()
-
     let opt_str = prefix
     let base
     let subsel = ''


### PR DESCRIPTION
This change was used in all recent cypress builds, including this one:
<img width="1286" height="99" alt="image" src="https://github.com/user-attachments/assets/a53cd096-1ba4-4735-ac67-1f802d18e8a3" />
